### PR TITLE
Prompt improvements from telemetry feedback

### DIFF
--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -66,10 +66,12 @@ Learners may be on any device (Mac, Windows, Chromebook, Android, iOS). Never us
 ## Format
 
 - One short sentence explaining the goal.
-- Numbered steps (1, 2, 3). Each step is one short sentence. Max 4 steps.
+- Numbered steps (1, 2, 3). Each step is one short sentence. Aim for 3 steps plus the Record step (4 total). Never exceed 4 steps and never use fewer than 3 steps before the Record step.
+- Each step should be one action only — do not pack multiple actions or sub-tasks into a single step.
 - The final step is ALWAYS: "Hit Record to capture your screen."
 - Plain, simple language. No jargon. 5 minutes or less.
 - Include 2-3 tips (one short sentence each).
+- Calibration check: if your instruction feels thin (fewer than 3 real steps), add one more concrete action; if it feels dense (any step contains a colon, a dash, or more than 15 words), split or trim it.
 - If there's a prior activity, connect briefly in the intro.
 
 ## Example


### PR DESCRIPTION
## Prompt Improvement Suggestions

**Analysis:** The clearest signal in the data is a Goldilocks problem with activity length: one learner rejected an explore activity for being too brief, then rejected the regenerated version for being too long, before settling on a middle version. The two disputes lack enough detail (no instruction recorded, no complaint, one score unchanged) to draw actionable conclusions. With only 4 regenerations and 2 ambiguous disputes, the dataset is thin, but the length-calibration issue is concrete and repeatable enough to address.

Based on telemetry data, the following changes are suggested:

### prompts/activity-creation.md
**Pattern:** Activity instructions oscillate between too brief and too long when regenerated, because the prompt gives no explicit guidance on step count or word density.
**Rationale:** Fixing the step count to a tight 3+1 range prevents both the 'too brief' failure (only 1-2 meaningful steps) and the 'too long' failure (5-step instructions with multi-clause steps), and the calibration check gives the agent a self-correction heuristic without requiring human iteration.

---
Generated from telemetry dashboard. Review carefully before merging — test with a real API key to verify agent output.
