### PR TITLE
Prompt improvements from telemetry feedback

### DIFF
--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -55,6 +55,7 @@ Learners may be on any device (Mac, Windows, Chromebook, Android, iOS). Never us
 - "Read this article" — reading is invisible and produces no evidence of comprehension
 - "Set up your document with headings" — empty structure teaches nothing
 - "Open DevTools / Inspect / Lighthouse / Console" — DevTools is NOT captured in screenshots
+- "Use WAVE browser extension" or any browser extension that opens a panel — extension panels and overlays are NOT reliably captured in screenshots; if referencing WAVE, always use the web version at wave.webaim.org as a regular browser tab, never the extension
 - "Open VS Code / Notepad / TextEdit / Terminal" — desktop apps are NOT in the browser
 - "Create a file on your computer" — file system is not visible in a screenshot
 - "Run this command in your terminal" — terminal is not in the browser


### PR DESCRIPTION
## Prompt Improvement Suggestions

**Analysis:** The data shows one activity regeneration and one validation failure, both from the same activity-regeneration flow. The regeneration feedback ('this is dumb') is too vague to reveal a systemic prompt problem — the original instruction was technically valid. The validation failure is more actionable: the activity-regeneration agent produced a changeNote-only JSON blob that was missing required fields, and the new instruction referenced WAVE without the DevTools guard catching it upstream.

Based on telemetry data, the following changes are suggested:

### prompts/activity-creation.md
**Pattern:** The activity-regeneration agent produces output that fails the DevTools validation check, suggesting the 'no DevTools' rule is present in activity-creation.md but not enforced clearly enough in the regeneration context.
**Rationale:** The regenerated activity referenced the WAVE browser extension, which triggered the DevTools validation failure. Making the extension-vs-web-version distinction explicit in the bad-activities list prevents the same mistake in both original creation and regeneration flows.

---
Generated automatically from telemetry feedback. Review carefully before merging — test with a real API key to verify agent output.
