### PR TITLE
Prompt improvements from telemetry feedback

### DIFF
--- a/prompts/activity-assessment.md
+++ b/prompts/activity-assessment.md
@@ -12,7 +12,7 @@ Assess whether the learner demonstrated UNDERSTANDING of the topic, not whether 
 - Feedback: 1-2 sentences about what you see and whether it demonstrates understanding of the goal.
 - Strengths: 1-3 bullet points, one sentence each. Focus on evidence of understanding.
 - Improvements: 1-3 bullet points, one sentence each. Suggest areas to explore deeper or misconceptions to address — never dictate specific content to add.
-- Score: 0.0 to 1.0 based on how well the work demonstrates understanding of the goal.
+- Score: 0.0 to 1.0 based on how well the work demonstrates understanding of the goal. Score against what the goal explicitly asked for — do not penalize for depth, length, or detail that the goal did not require. If the learner fulfilled the stated goal, the score must reflect that even if the work could theoretically go deeper.
 - Recommendation:
   - "advance" -- work shows solid understanding, move on
   - "revise" -- shows gaps in understanding that need addressing

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -54,11 +54,12 @@ Learners may be on any device (Mac, Windows, Chromebook, Android, iOS). Never us
 - "Go to [article/page] and capture it" — screenshotting someone else's content shows nothing
 - "Read this article" — reading is invisible and produces no evidence of comprehension
 - "Set up your document with headings" — empty structure teaches nothing
-- "Open DevTools / Inspect / Lighthouse / Console" — DevTools is NOT captured in screenshots
+- "Open DevTools / Inspect / Lighthouse / Console" — DevTools is NOT captured in screenshots. This rule applies even during regeneration — do NOT reintroduce DevTools in a revised activity.
+- "Use WAVE extension" or "install a browser extension" — extension panels and popups are NOT reliably captured in screenshots; use the web version at wave.webaim.org in its own tab ONLY if the work product tab is not needed simultaneously
 - "Open VS Code / Notepad / TextEdit / Terminal" — desktop apps are NOT in the browser
 - "Create a file on your computer" — file system is not visible in a screenshot
 - "Run this command in your terminal" — terminal is not in the browser
-- "Visit site A, then visit site B" — only one page can be recorded
+- "Visit site A, then visit site B" — only one page can be recorded; if a tool like WAVE is needed, the learner should write findings in their document afterward, not switch tabs mid-activity
 - "Find X on the page" — finding leaves no visible trace
 - "Click the button" — clicking is invisible in a screenshot
 - "Try different options" — vague, no single recordable outcome

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -11,9 +11,10 @@ This means:
 - The activity MUST lead to exactly ONE visible result on ONE page.
 - The LAST step MUST always be exactly: "Hit Record to capture your screen."
 - Everything the learner did must be visible in that one browser tab screenshot.
-- Never ask the learner to visit multiple sites, compare pages, or do multiple separate tasks.
+- Never ask the learner to visit multiple sites, compare pages, or do multiple separate tasks. If research on an external site is needed, the learner should do that research and then navigate back to the work product document before hitting Record — the recorded tab must always be the work product.
 - Never ask the learner to do something invisible (read, think, click, find).
 - NEVER ask the learner to open a desktop app, text editor, terminal, file manager, or anything outside the browser. These are NOT visible in the screenshot.
+- When regenerating a rejected activity, re-read every step and confirm each one obeys this rule before responding. Do not carry over rule violations from the original instruction.
 
 ## Single document rule
 


### PR DESCRIPTION
## Prompt Improvement Suggestions

**Analysis:** The data shows three distinct issues: an assessment agent scoring too harshly when the learner met the literal activity goal (leading to a dispute and upward revision), an activity-regeneration agent producing instructions that reference DevTools despite explicit rules against it (validation failure), and a regenerated activity still directing learners to open a second browser tab for WAVE despite the one-tab screenshot rule. The sample size is small but each issue points to a specific, addressable gap in the prompts.

Based on telemetry data, the following changes are suggested:

### prompts/activity-assessment.md
**Pattern:** Assessment agent penalizes learners for not meeting unstated expectations (e.g. depth of explanation) when the stated goal only asked for identification, causing disputes and score revisions.
**Rationale:** The dispute shows the learner correctly identified three barriers as asked, but was scored 0.62 because the explanations were brief — a depth expectation nowhere in the goal. Anchoring scoring strictly to the stated goal prevents this mismatch and reduces disputes.

### prompts/activity-creation.md
**Pattern:** Activity-regeneration agent produces instructions referencing DevTools or multi-tab workflows despite rules against them, causing validation failures.
**Rationale:** The validation failure shows the regeneration agent reintroduced DevTools despite the existing ban, and the regenerated activity still sent learners to WAVE in a second tab. Explicitly calling out that these rules apply during regeneration too, and clarifying the WAVE/extension edge case, closes both gaps.

### prompts/activity-creation.md
**Pattern:** Regenerated activities still violate the single-tab rule by directing learners to open a second tab (e.g. an external checker or a site to audit) while their work product document is open.
**Rationale:** The regenerated WAVE activity still sent learners to a second tab, showing the agent doesn't consistently enforce the one-tab rule when rewriting. Clarifying that the recorded tab must always be the work product document, and adding an explicit regeneration self-check, directly addresses this recurring slip.

---
Generated automatically from telemetry feedback. Review carefully before merging — test with a real API key to verify agent output.
