### PR TITLE
Prompt improvements from telemetry feedback

### DIFF
--- a/prompts/activity-assessment.md
+++ b/prompts/activity-assessment.md
@@ -6,6 +6,8 @@ Evaluate a learner's draft submission by looking at their screenshot.
 
 Assess whether the learner demonstrated UNDERSTANDING of the topic, not whether they wrote specific words or followed a template. The learner chooses their own content — your job is to evaluate whether that content shows genuine comprehension. If the learner took a different approach than expected but clearly understands the material, that's a strength, not a weakness. Improvements should point the learner toward deeper understanding, not toward specific content you want to see.
 
+Critical: score against what the activity goal literally asked for, not against an ideal version of the activity. If the goal says "list three barriers" and the learner listed three barriers, that criterion is met regardless of which barriers they chose or how deeply they explained them. Never reduce a score because the learner's examples don't match the examples you would have chosen.
+
 ## Rules
 
 - Write in plain, simple language. Short sentences. No jargon.

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -4,6 +4,8 @@ Generate a brief instruction for one learning activity.
 
 ## THE ONE RULE
 
+> **Hard constraint — checked automatically after every response:** Never reference DevTools, browser extensions, browser panels, or any tool that opens outside the main browser tab (including WAVE extension, axe, Lighthouse, browser accessibility checkers, or any install/add-on step). If your activity requires one of these, replace it with a web-based alternative or a direct observation task.
+
 Every activity ends with one screenshot of the learner's browser tab. The learner clicks "Record" to capture their active browser tab. An AI then looks at that single screenshot to assess their work.
 
 This means:

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -55,6 +55,8 @@ Learners may be on any device (Mac, Windows, Chromebook, Android, iOS). Never us
 - "Read this article" — reading is invisible and produces no evidence of comprehension
 - "Set up your document with headings" — empty structure teaches nothing
 - "Open DevTools / Inspect / Lighthouse / Console" — DevTools is NOT captured in screenshots
+- "Use a browser extension" or "Install WAVE / axe / Lighthouse" — browser extensions and their panels are NOT captured in screenshots
+- "Use the browser's built-in accessibility checker" — any tool that opens outside the main page content is NOT captured in screenshots
 - "Open VS Code / Notepad / TextEdit / Terminal" — desktop apps are NOT in the browser
 - "Create a file on your computer" — file system is not visible in a screenshot
 - "Run this command in your terminal" — terminal is not in the browser

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -47,6 +47,8 @@ ALWAYS do these:
 Good: "Research common web accessibility barriers and write about what you found in your document."
 Bad: "Add a section titled 'Common Barriers' with bullet points covering visual, motor, and cognitive disabilities."
 
+Also avoid activities that chain an external tool step with a writing step in the same activity (e.g. "use WAVE to find barriers AND write explanations"). If tool use and reflection are both needed, make them separate activities.
+
 ## Platform rule
 
 Learners may be on any device (Mac, Windows, Chromebook, Android, iOS). Never use platform-specific shortcuts like "press F12" or "Ctrl+Shift+I". Describe actions using menu paths that work everywhere.

--- a/prompts/learner-profile-update.md
+++ b/prompts/learner-profile-update.md
@@ -19,7 +19,8 @@ Rules for learner feedback (CRITICAL — always apply these when learnerFeedback
 - Extract and store experience level in preferences.experienceLevel (e.g. "beginner", "computer novice", "experienced developer"). If it contradicts a previous value, reconcile them (e.g. "computer novice but experienced coder").
 - Extract and store any tool preferences, software availability, or constraints in preferences.
 - If the learner expresses confusion or inability (e.g. "I don't know how to right click"), add relevant notes to weaknesses or recurringSupport.
-- If the feedback reveals accessibility needs, add to accessibilityNeeds.
+- If the feedback reveals accessibility needs, add to accessibilityNeeds. Accessibility needs include physical or motor constraints that affect typing speed or volume (e.g. "cannot type fast due to disability", "uses voice input", "one-handed typing") — store these explicitly in accessibilityNeeds with enough detail for the activity-creation agent to reduce writing load.
+- If the learner mentions they are on a mobile device (phone, tablet) AND has a typing constraint, add "low-typing activities preferred" to preferences so downstream agents can act on it immediately.
 - ALWAYS update at least one field when feedback is provided. The learner expects their input to be reflected.
 
 General rules:


### PR DESCRIPTION
## Prompt Improvement Suggestions

**Analysis:** The dominant pattern is DevTools-related validation failures in both activity-creation and activity-regeneration agents, suggesting the prohibition isn't prominent enough or specific enough to prevent the model from reaching for browser-based audit tools that open panels outside the tab. A secondary pattern is activity over-complexity — the WAVE accessibility checker instruction appeared in two disputes and one regeneration, indicating that multi-tool or multi-step activities with external dependencies (browser extensions, third-party web tools) consistently cause learner confusion and incomplete submissions. The learner feedback also reveals an unhandled accessibility/device constraint (phone + typing disability) that wasn't captured in the profile until after a regeneration, suggesting the activity-creation agent should be more proactive about low-typing alternatives when profile context is available.

Based on telemetry data, the following changes are suggested:

### prompts/activity-creation.md
**Pattern:** Activity-creation and activity-regeneration agents keep generating activities that reference DevTools, browser panels, or browser extensions, causing repeated validation failures.
**Rationale:** Both validation failures were triggered by activities referencing browser accessibility tools (WAVE extension, built-in browser checker). The existing prohibition mentions DevTools by name but doesn't generalize to browser extensions or built-in browser panels, so the model keeps finding adjacent workarounds. Making the prohibition explicit for extensions and built-in browser tools closes that gap.

### prompts/activity-creation.md
**Pattern:** Activity-creation and activity-regeneration agents keep generating activities that reference DevTools, browser panels, or browser extensions, causing repeated validation failures.
**Rationale:** Placing a hard-constraint callout at the very top of the prompt — before any other rules — makes it the first thing the model processes, reducing the chance it is overridden by later, more specific task instructions. The WAVE extension appeared as a problematic suggestion in three separate incidents, so naming it explicitly here prevents recurrence.

### prompts/activity-creation.md
**Pattern:** Activities that combine choosing a website, installing or using an external checker tool, and writing explanations in one step are consistently too complex, leading to disputes, regenerations, and off-task submissions.
**Rationale:** The WAVE-related activity appeared in both disputes and a regeneration; in each case the learner either didn't attempt it or submitted unrelated work. The root cause is that tool setup plus analysis plus writing is too much for one 5-minute activity. This addition reinforces the existing small-steps rule with a concrete pattern from the failure data.

### prompts/activity-assessment.md
**Pattern:** The assessment agent penalized a learner for not meeting an implicit content standard (specific barrier types, explanation depth) that wasn't stated in the activity goal, triggering a successful dispute.
**Rationale:** The first dispute shows the assessment agent scored 0.62 because it judged the quality and type of barriers listed, even though the goal only asked the learner to notice and name three. Adding an explicit instruction to score against the literal goal prevents the agent from importing unstated criteria that learners then reasonably dispute.

### prompts/learner-profile-update.md
**Pattern:** A learner's typing disability and phone-only access wasn't captured in their profile until after a regeneration was already needed, meaning the activity-creation agent had no signal to reduce typing load proactively.
**Rationale:** The regeneration data shows the learner's phone + typing disability was only surfaced through a regeneration complaint, not proactively. More explicit guidance on what counts as an accessibility need — and an actionable preference flag — means the profile agent will capture these signals earlier and the activity-creation agent will have the context it needs before generating the next activity.

---
Generated automatically from telemetry feedback. Review carefully before merging — test with a real API key to verify agent output.
