### PR TITLE
Prompt improvements from telemetry feedback

### DIFF
--- a/prompts/activity-assessment.md
+++ b/prompts/activity-assessment.md
@@ -14,6 +14,7 @@ Assess whether the learner demonstrated UNDERSTANDING of the topic, not whether 
 - Strengths: 1-3 bullet points, one sentence each. Focus on evidence of understanding.
 - Improvements: 1-3 bullet points, one sentence each. Suggest areas to explore deeper or misconceptions to address — never dictate specific content to add.
 - Score: 0.0 to 1.0 based on how well the work demonstrates understanding of the goal.
+- Scoring calibration: if the learner completed the task as described and produced relevant written work — even if brief — the score should be at least 0.7. Reserve scores below 0.5 for cases where the screenshot shows no attempt at the core task (wrong page, blank document, or entirely off-topic content). Do not penalize brevity, unconventional structure, or content choices that differ from what you expected.
 - Recommendation:
   - "advance" -- work shows solid understanding, move on
   - "revise" -- shows gaps in understanding that need addressing

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -54,7 +54,7 @@ Learners may be on any device (Mac, Windows, Chromebook, Android, iOS). Never us
 - "Go to [article/page] and capture it" — screenshotting someone else's content shows nothing
 - "Read this article" — reading is invisible and produces no evidence of comprehension
 - "Set up your document with headings" — empty structure teaches nothing
-- "Open DevTools / Inspect / Lighthouse / Console" — DevTools is NOT captured in screenshots
+- "Open DevTools / Inspect / Lighthouse / Console / Accessibility panel" — DevTools and ALL browser panels (including built-in accessibility checkers) are NOT captured in screenshots. Never reference F12, Inspect Element, Lighthouse, the browser console, or any browser panel — these are invisible to the screenshot. Only content in the main browser viewport is visible.
 - "Open VS Code / Notepad / TextEdit / Terminal" — desktop apps are NOT in the browser
 - "Create a file on your computer" — file system is not visible in a screenshot
 - "Run this command in your terminal" — terminal is not in the browser

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -11,7 +11,7 @@ This means:
 - The activity MUST lead to exactly ONE visible result on ONE page.
 - The LAST step MUST always be exactly: "Hit Record to capture your screen." This applies to every activity type without exception — including diagnostic activities. Never end on a reflection, a search, or any other action.
 - Everything the learner did must be visible in that one browser tab screenshot.
-- Never ask the learner to visit multiple sites, compare pages, or do multiple separate tasks.
+- Never ask the learner to visit multiple sites, compare pages, or do multiple separate tasks. This includes instructions like 'open a website in another tab then return to your document' — the learner's active tab at Record time must be the work product document, and any research must be described as something done before returning to the document, not as a simultaneous multi-tab workflow. If the activity requires visiting an external resource (e.g. a checker or reference site), instruct the learner to finish there and then return to their document as the final action before hitting Record.
 - Never ask the learner to do something invisible (read, think, click, find).
 - NEVER ask the learner to open a desktop app, text editor, terminal, file manager, or anything outside the browser. These are NOT visible in the screenshot.
 

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -9,7 +9,7 @@ Every activity ends with one screenshot of the learner's browser tab. The learne
 This means:
 - The ENTIRE activity MUST happen inside a browser tab. The screenshot only captures what is in the browser.
 - The activity MUST lead to exactly ONE visible result on ONE page.
-- The LAST step MUST always be exactly: "Hit Record to capture your screen."
+- The LAST step MUST always be exactly: "Hit Record to capture your screen." This applies to every activity type without exception — including diagnostic activities. Never end on a reflection, a search, or any other action.
 - Everything the learner did must be visible in that one browser tab screenshot.
 - Never ask the learner to visit multiple sites, compare pages, or do multiple separate tasks.
 - Never ask the learner to do something invisible (read, think, click, find).


### PR DESCRIPTION
## Prompt Improvement Suggestions

**Analysis:** The data shows three recurring problems: (1) the activity-creation and activity-regeneration agents keep generating DevTools-based activities despite an explicit prohibition, suggesting the existing rule isn't prominent or specific enough; (2) assessment disputes cluster around the agent penalizing learners for content choices rather than evaluating demonstrated understanding, especially when work is present but brief; (3) a diagnostic-creation agent is producing outputs without the required 'Hit Record' final step, indicating the prompt for that agent either lacks the rule or states it ambiguously.

Based on telemetry data, the following changes are suggested:

### prompts/activity-creation.md
**Pattern:** Activity-creation and activity-regeneration agents repeatedly generate DevTools-based activities despite an existing rule against it.
**Rationale:** Two validation failures and one regeneration all involved DevTools or browser-panel-based accessibility checks. Making the prohibition more explicit and listing the specific variants (Lighthouse, built-in accessibility checkers) that keep appearing should prevent the agent from reaching for these tools.

### prompts/activity-assessment.md
**Pattern:** Assessment agent penalizes learners for brevity or content choices rather than evaluating whether understanding was demonstrated, triggering disputes.
**Rationale:** Both successful disputes involved the agent scoring work below 0.65 when the learner had completed the task as asked — once for brief explanations, once for content framing. Adding an explicit calibration floor for completed work aligns the scoring behavior with the assessment philosophy already stated in the prompt.

### prompts/activity-creation.md
**Pattern:** The diagnostic-creation agent is producing outputs without a 'Hit Record' final step, causing validation failures.
**Rationale:** The validation failure shows a diagnostic activity that ended with a reflection prompt rather than the Record step. Explicitly calling out that this rule applies to diagnostics too should close that gap.

### prompts/activity-creation.md
**Pattern:** Activity instructions asking learners to visit a second website in a separate tab produce confusion, disputes, and regenerations because the screenshot can only capture one tab.
**Rationale:** Two disputes and one regeneration involved instructions that sent learners to a second tab (a website to audit, WAVE, WordPress Playground) and then back to their document — a pattern that confused learners about which tab to have active when recording. Clarifying the expected tab-switching sequence should reduce this confusion.

---
Generated automatically from telemetry feedback. Review carefully before merging — test with a real API key to verify agent output.
