### PR TITLE
Prompt improvements from telemetry feedback

### DIFF
--- a/prompts/activity-assessment.md
+++ b/prompts/activity-assessment.md
@@ -21,6 +21,10 @@ Assess whether the learner demonstrated UNDERSTANDING of the topic, not whether 
 - Set "passed" to true if this is a final activity and score >= 0.7, or if non-final and you recommend "advance" or "continue".
 - For revisions, briefly note what improved.
 
+## Scope of assessment
+
+You can only evaluate what is visible in the screenshot in front of you. Never reference, assume, or penalize based on prior activities, prior conversations, or work that is not visible in this screenshot. If the learner refers to prior context you cannot see, acknowledge the limitation rather than guessing.
+
 Respond with ONLY valid JSON, no markdown fencing:
 
 {

--- a/prompts/activity-assessment.md
+++ b/prompts/activity-assessment.md
@@ -12,7 +12,7 @@ Assess whether the learner demonstrated UNDERSTANDING of the topic, not whether 
 - Write in plain, simple language. Short sentences. No jargon.
 - Feedback: 1-2 sentences about what you see and whether it demonstrates understanding of the goal.
 - Strengths: 1-3 bullet points, one sentence each. Focus on evidence of understanding.
-- Improvements: 1-3 bullet points, one sentence each. Suggest areas to explore deeper or misconceptions to address — never dictate specific content to add.
+- Improvements: 1-3 bullet points, one sentence each. Suggest areas to explore deeper or misconceptions to address — never dictate specific content to add. Never penalize the learner for choosing content, examples, or framing that differs from what you expected, as long as it satisfies the activity goal. If you are uncertain whether the learner's interpretation is valid, resolve the doubt in their favor.
 - Score: 0.0 to 1.0 based on how well the work demonstrates understanding of the goal.
 - Recommendation:
   - "advance" -- work shows solid understanding, move on

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -54,7 +54,7 @@ Learners may be on any device (Mac, Windows, Chromebook, Android, iOS). Never us
 - "Go to [article/page] and capture it" — screenshotting someone else's content shows nothing
 - "Read this article" — reading is invisible and produces no evidence of comprehension
 - "Set up your document with headings" — empty structure teaches nothing
-- "Open DevTools / Inspect / Lighthouse / Console" — DevTools is NOT captured in screenshots
+- "Open DevTools / Inspect / Lighthouse / Console" — DevTools is NOT captured in screenshots. This ban applies to ALL browser developer tools regardless of how they are described: 'Inspect Element', 'browser console', 'Lighthouse audit', 'accessibility panel', 'network tab', 'built-in browser accessibility check', and any instruction to open a panel via right-click or browser menu. If an activity involves accessibility checking, use only external web tools (e.g. wave.webaim.org) that open as a full browser tab.
 - "Open VS Code / Notepad / TextEdit / Terminal" — desktop apps are NOT in the browser
 - "Create a file on your computer" — file system is not visible in a screenshot
 - "Run this command in your terminal" — terminal is not in the browser

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -53,6 +53,8 @@ Learners may be on any device (Mac, Windows, Chromebook, Android, iOS). Never us
 
 - "Go to [article/page] and capture it" — screenshotting someone else's content shows nothing
 - "Read this article" — reading is invisible and produces no evidence of comprehension
+- "Read it aloud" or "read through your document" as the primary or only action — reading and listening are invisible and produce no evidence of change
+- "Polish for clarity/tone" without a concrete writing action — if the activity is a final polish, the instruction must require the learner to make at least one specific, visible change to the document (e.g., rewrite the opening sentence, remove a named type of language, merge two paragraphs) so the screenshot shows new content
 - "Set up your document with headings" — empty structure teaches nothing
 - "Open DevTools / Inspect / Lighthouse / Console" — DevTools is NOT captured in screenshots. This ban applies to ALL browser developer tools regardless of how they are described: 'Inspect Element', 'browser console', 'Lighthouse audit', 'accessibility panel', 'network tab', 'built-in browser accessibility check', and any instruction to open a panel via right-click or browser menu. If an activity involves accessibility checking, use only external web tools (e.g. wave.webaim.org) that open as a full browser tab.
 - "Open VS Code / Notepad / TextEdit / Terminal" — desktop apps are NOT in the browser

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -11,7 +11,7 @@ This means:
 - The activity MUST lead to exactly ONE visible result on ONE page.
 - The LAST step MUST always be exactly: "Hit Record to capture your screen."
 - Everything the learner did must be visible in that one browser tab screenshot.
-- Never ask the learner to visit multiple sites, compare pages, or do multiple separate tasks.
+- Never ask the learner to visit multiple sites, compare pages, or do multiple separate tasks. Never require the learner to install a browser extension — extension availability varies by device and browser and cannot be assumed. If an accessibility tool is needed, use only tools that work as a standalone website (e.g. wave.webaim.org) without installation. Never instruct the learner to split or tile browser windows or keep two tabs visible simultaneously — the screenshot captures one tab.
 - Never ask the learner to do something invisible (read, think, click, find).
 - NEVER ask the learner to open a desktop app, text editor, terminal, file manager, or anything outside the browser. These are NOT visible in the screenshot.
 

--- a/prompts/course-creation.md
+++ b/prompts/course-creation.md
@@ -33,6 +33,8 @@ You MUST specify the document type in `workProductTool` (e.g. "Google Doc", "Cod
 - Never assume the learner already knows the subject matter. Each activity should be a learning opportunity, not a test of existing knowledge.
 - Each activity goal must describe ONE simple task with ONE visible outcome on ONE webpage (the work product document). The learner will be assessed by a screenshot of a single browser tab.
 - NEVER write goals that involve multiple websites, multiple tools, or multiple outcomes (e.g. "audit three websites" is BAD — instead, create three separate activities, one per website).
+- NEVER write goals that require installing a browser extension or splitting the screen across multiple tabs. If accessibility checking is part of the goal, assume the learner will use a web-based tool that opens in a single browser tab.
+- NEVER write goals whose primary action is invisible (reading, listening, thinking, clicking). Every goal must result in new visible text or content added to the work product document.
 - All activities must be doable entirely in the browser. Never reference desktop apps, terminals, or file system operations.
 - Generate a maximum of 5 activities total. Combine objectives into single activities where possible. Prefer fewer, well-chosen steps over an exhaustive list.
 - The last activity must always be type "final".


### PR DESCRIPTION
## Prompt Improvement Suggestions

**Analysis:** Three distinct failure patterns emerge: (1) the assessment agent penalizes learners for content choices that fall within the activity's stated scope, triggering disputes that are often partially or fully upheld; (2) the activity-creation agent repeatedly generates activities that reference DevTools or produce no visible work product, causing validation failures; (3) activity instructions sometimes introduce multi-step complexity (WAVE extension, multiple tabs, platform-specific tools) that confuses learners and leads to regeneration requests or failed attempts.

Based on telemetry data, the following changes are suggested:

### prompts/activity-assessment.md
**Pattern:** Assessment agent penalizes content choices (wrong barriers named, wrong framing) rather than evaluating demonstrated understanding, causing upheld disputes.
**Rationale:** Multiple upheld disputes show the assessor down-scoring learners for reasonable content choices (naming valid but unexpected accessibility barriers, using their own framing for a 'personal pitch'). Making the benefit-of-the-doubt rule explicit should reduce these disputes at the source.

### prompts/activity-assessment.md
**Pattern:** Assessment agent references prior work or prior conversations it cannot see, leading to unfair penalties and learner confusion.
**Rationale:** Two disputes arose because the assessor made claims about prior work ('those values are the ones we talked about before', content not visible in screenshot) it could not actually see. Explicitly bounding the assessment to the visible screenshot prevents this class of error.

### prompts/activity-creation.md
**Pattern:** Activity-creation agent repeatedly generates activities referencing DevTools or browser inspection panels, causing recurring validation failures.
**Rationale:** Two validation failures share the exact same DevTools error, and the phrasing in the failures ('built-in browser accessibility check', browser panels) suggests the agent is finding loopholes around the existing prohibition. Closing those loopholes explicitly and redirecting to tab-based alternatives should eliminate this failure mode.

### prompts/activity-creation.md
**Pattern:** Activity-creation agent generates 'polish/read aloud' final activities that produce no new visible work, causing validation failures for invisible actions.
**Rationale:** Two validation failures involved final-activity instructions whose core action was reading aloud or general polishing with no concrete visible output. Adding explicit rules against these patterns with a redirect toward concrete writing actions closes this gap.

### prompts/activity-creation.md
**Pattern:** Activity instructions introduce third-party browser extensions and multi-tab workflows that confuse learners and cause failed attempts and regenerations.
**Rationale:** The WAVE extension requirement appeared in two separate activities and contributed to both a regeneration and a failed submission; one learner explicitly said the activity was 'too complicated'. Banning extension installs and multi-tab arrangements removes this recurring source of friction.

### prompts/course-creation.md
**Pattern:** Course-creation agent designs activities with multi-website or multi-tool goals that downstream agents then struggle to reduce to a single-tab, single-outcome instruction.
**Rationale:** The extension-and-multi-tab pattern originates in activity goals set by the course-creation agent before the activity-creation agent ever sees them; blocking it here prevents the problem from being passed downstream where it is harder to catch.

---
Generated automatically from telemetry feedback. Review carefully before merging — test with a real API key to verify agent output.
