### PR TITLE
Prompt improvements from telemetry feedback

### DIFF
--- a/prompts/activity-assessment.md
+++ b/prompts/activity-assessment.md
@@ -6,6 +6,8 @@ Evaluate a learner's draft submission by looking at their screenshot.
 
 Assess whether the learner demonstrated UNDERSTANDING of the topic, not whether they wrote specific words or followed a template. The learner chooses their own content — your job is to evaluate whether that content shows genuine comprehension. If the learner took a different approach than expected but clearly understands the material, that's a strength, not a weakness. Improvements should point the learner toward deeper understanding, not toward specific content you want to see.
 
+You can only assess what is visible in the screenshot. Never infer, assume, or critique content, choices, or decisions from prior activities that are not visible in the current screenshot. If the learner references prior work or uses values/content established earlier in the course, treat those choices as given — do not question whether they are the right choices unless you can see clear evidence of a problem in the current screenshot.
+
 ## Rules
 
 - Address the learner directly as "you" — never refer to them as "the learner" or in third person.

--- a/prompts/activity-assessment.md
+++ b/prompts/activity-assessment.md
@@ -9,6 +9,8 @@ Assess whether the learner demonstrated UNDERSTANDING of the topic, not whether 
 ## Rules
 
 - Address the learner directly as "you" — never refer to them as "the learner" or in third person.
+- If the work product appears to continue below the visible viewport (e.g. the document is clearly long or content is cut off), do not penalize the learner for content you cannot see. Assess what is visible and note that additional content may exist below the fold — never score down solely because the full document isn't visible in one screenshot.
+- Never penalize a learner for a format choice (bullets, prose, headers, etc.) that was not explicitly prohibited by the activity instructions. If the instructions said "write freely" or did not specify format, any organized format that addresses the goal is acceptable.
 - Write in plain, simple language. Short sentences. No jargon.
 - Feedback: 1-2 sentences about what you see and whether it demonstrates understanding of the goal.
 - Strengths: 1-3 bullet points, one sentence each. Focus on evidence of understanding.

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -15,6 +15,10 @@ This means:
 - Never ask the learner to do something invisible (read, think, click, find).
 - NEVER ask the learner to open a desktop app, text editor, terminal, file manager, or anything outside the browser. These are NOT visible in the screenshot.
 
+## Final activities must produce visible output
+
+When the activity type is `final`, the learner must still produce a concrete, visible change in the work product — not just read, revise silently, or polish. The final step before Record must result in new or rewritten text that is visible on screen. Frame the task as a specific rewrite, a new closing section, or a targeted edit with a visible result — never as a general "read and polish" loop with no defined output.
+
 ## Single work product rule
 
 The entire course builds ONE work product in ONE place. The input tells you the `workProduct` name and `workProductTool` (e.g. "Google Doc", "WordPress Playground post", "CodePen pen"). Every activity must direct the learner back to this same work product — NEVER ask them to create a new one. The first activity should say "Create a new [workProductTool] called [workProduct]". All subsequent activities should say "Open your [workProduct]" or "Return to your [workProduct]" and add to, revise, or refine what's already there. Use language appropriate to the tool — e.g. "post" for WordPress, "pen" for CodePen — not "document" for everything.

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -62,7 +62,7 @@ When writing steps for a specific browser-based platform (WordPress Playground, 
 - "Read through your document and revise it" as the main step — reading is invisible; the step must end with a visible, written change in the work product
 - "Polish your document" without a concrete visible output — polishing alone produces no assessable evidence; always pair it with a specific rewrite, addition, or visible transformation that will appear on screen
 - "Set up your document/post with headings" — empty structure teaches nothing
-- "Open DevTools / Inspect / Lighthouse / Console" — DevTools is NOT captured in screenshots
+- "Open DevTools / Inspect / Lighthouse / Console / Accessibility panel / Performance tab" — DevTools and ALL browser panels are NOT captured in screenshots; this includes any instruction to right-click and inspect, open browser developer tools, or use any built-in browser audit tool accessed via F12 or browser menus
 - "Open VS Code / Notepad / TextEdit / Terminal" — desktop apps are NOT in the browser
 - "Create a file on your computer" — file system is not visible in a screenshot
 - "Run this command in your terminal" — terminal is not in the browser

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -53,6 +53,8 @@ Learners may be on any device (Mac, Windows, Chromebook, Android, iOS). Never us
 
 - "Go to [article/page] and capture it" — screenshotting someone else's content shows nothing
 - "Read this article" — reading is invisible and produces no evidence of comprehension
+- "Read through your document and revise it" as the main step — reading is invisible; the step must end with a visible, written change in the work product
+- "Polish your document" without a concrete visible output — polishing alone produces no assessable evidence; always pair it with a specific rewrite, addition, or visible transformation that will appear on screen
 - "Set up your document/post with headings" — empty structure teaches nothing
 - "Open DevTools / Inspect / Lighthouse / Console" — DevTools is NOT captured in screenshots
 - "Open VS Code / Notepad / TextEdit / Terminal" — desktop apps are NOT in the browser

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -53,6 +53,8 @@ Bad: "Add a section titled 'Common Barriers' with bullet points covering visual,
 
 Learners may be on any device (Mac, Windows, Chromebook, Android, iOS). Never use platform-specific shortcuts like "press F12" or "Ctrl+Shift+I". Describe actions using menu paths that work everywhere.
 
+When writing steps for a specific browser-based platform (WordPress Playground, Figma, CodePen, Notion, Replit, etc.), never describe UI elements you are not certain exist in that platform's current interface. Use generic, navigational language ("find the Posts section", "look for the menu to create a new post") rather than asserting specific layout details ("click the left sidebar", "find the top-right button"). If you are uncertain about the exact UI, describe the goal of the navigation step rather than a specific element to click.
+
 ## Bad activities (NEVER do these)
 
 - "Go to [article/page] and capture it" — screenshotting someone else's content shows nothing


### PR DESCRIPTION
## Prompt Improvement Suggestions

**Analysis:** Three patterns dominate: (1) the activity-creation agent repeatedly generates 'final' activities that involve only reading/revising without producing new visible work, triggering validation failures; (2) the assessment agent penalizes learners for content that scrolls below the viewport even when the activity instruction allowed long-form output, causing disputes and score reversals; (3) the activity-creation agent occasionally generates DevTools-dependent steps and platform-specific UI instructions (e.g. 'left sidebar') that don't match what learners actually see. A smaller but consistent dispute pattern shows the assessment agent penalizing format choices (bullets vs. prose) and prior-context decisions that weren't constrained by the instructions.

Based on telemetry data, the following changes are suggested:

### prompts/activity-creation.md
**Pattern:** Final-type activities that only ask the learner to read, revise, or polish produce no new visible work in the viewport, causing repeated validation failures and assessment disputes.
**Rationale:** Three of the five validation failures were final-type activities where the primary action was reading or polishing with no concrete visible output specified. Adding these explicitly to the bad-activities list gives the agent a direct rule to check against before generating final-activity steps.

### prompts/activity-creation.md
**Pattern:** Final-type activities need a concrete visible output requirement to pass validation, not just a polish instruction.
**Rationale:** The validation failures and assessment disputes for final activities share a root cause: the prompt had no explicit rule requiring final activities to produce a visible artifact. This new section closes that gap directly.

### prompts/activity-assessment.md
**Pattern:** The assessment agent penalizes learners for content below the viewport even when the activity's own instructions caused the long output, leading to score reversals after disputes.
**Rationale:** The WordPress timeline dispute (0.2 → 0.7 reversal) and the bullets/structure dispute (0.82 → 0.88 reversal) both show the assessment agent penalizing learners for things the instructions did not prohibit. These two explicit rules directly address both failure modes.

### prompts/activity-assessment.md
**Pattern:** The assessment agent references prior work or prior context it cannot see, then walks back the critique in revised assessments, eroding learner trust.
**Rationale:** Two disputes (values dispute at 0.45, framing dispute at 0.55 → 0.65) involved the assessor second-guessing prior decisions the learner made in earlier activities. This rule prevents the agent from critiquing out-of-scope prior context it cannot verify.

### prompts/activity-creation.md
**Pattern:** The activity-creation agent generates instructions referencing specific UI elements (e.g. 'left sidebar') that don't exist in the tool's actual interface, causing regenerations.
**Rationale:** The WordPress Playground regeneration was triggered entirely by a step referencing a 'left sidebar' that doesn't exist in that interface. This rule instructs the agent to use goal-oriented navigation language instead of asserting specific UI details it cannot verify.

### prompts/activity-creation.md
**Pattern:** The activity-creation agent generates DevTools-dependent steps despite an existing rule, suggesting the rule needs stronger emphasis and more specific examples.
**Rationale:** One validation failure was an activity that slipped through by using a built-in browser accessibility checker accessed through DevTools. Expanding the example list to explicitly cover browser panels and audit tools closes this loophole.

---
Generated automatically from telemetry feedback. Review carefully before merging — test with a real API key to verify agent output.
