### PR TITLE
Fix data loss on sign-out/sign-in cycle

### DIFF
--- a/js/sync.js
+++ b/js/sync.js
@@ -84,7 +84,9 @@ export async function loadAll() {
   if (!await isLoggedIn()) return;
 
   const res = await authenticatedFetch('/v1/sync');
-  if (!res.ok) return;
+  if (!res.ok) {
+    throw new Error(`Failed to load data from server: ${res.status}`);
+  }
 
   const items = await res.json();
   const serverKeys = new Set();

--- a/src/components/modals/LoginModal.jsx
+++ b/src/components/modals/LoginModal.jsx
@@ -6,6 +6,7 @@ import PasswordField from '../PasswordField.jsx';
 import { getPreferences, savePreferences } from '../../../js/storage.js';
 import * as sync from '../../../js/sync.js';
 import { loadCourses, invalidateCoursesCache } from '../../../js/courseOwner.js';
+import { notifySyncFailure } from '../../lib/syncDebounce.js';
 import { forgotPassword } from '../../../js/auth.js';
 
 export default function LoginModal({ onSuccess, message }) {
@@ -33,7 +34,9 @@ export default function LoginModal({ onSuccess, message }) {
       // Pull server data first (server is source of truth)
       try {
         await sync.loadAll();
-      } catch { /* offline — keep local data */ }
+      } catch (err) {
+        notifySyncFailure('loadAll', err);
+      }
 
       // Sync auth name into local preferences
       if (authUser?.name) {

--- a/src/contexts/AppContext.jsx
+++ b/src/contexts/AppContext.jsx
@@ -3,6 +3,7 @@ import { getPreferences } from '../../js/storage.js';
 import { loadCourses, invalidateCoursesCache } from '../../js/courseOwner.js';
 import * as sync from '../../js/sync.js';
 import * as auth from '../../js/auth.js';
+import { notifySyncFailure } from '../lib/syncDebounce.js';
 
 const AppContext = createContext(null);
 
@@ -36,7 +37,7 @@ export function AppProvider({ children }) {
       const courses = await loadCourses();
 
       if (await auth.isLoggedIn()) {
-        try { await sync.loadAll(); } catch { /* offline */ }
+        try { await sync.loadAll(); } catch (err) { notifySyncFailure('loadAll', err); }
       }
 
       const preferences = await getPreferences();
@@ -56,7 +57,7 @@ export function AppProvider({ children }) {
         const preferences = await getPreferences();
         const courses = await loadCourses();
         dispatch({ type: 'INIT_DATA', payload: { preferences, courses } });
-      } catch { /* offline or session expired — handled elsewhere */ }
+      } catch (err) { notifySyncFailure('loadAll', err); }
     };
     document.addEventListener('visibilitychange', handleVisibility);
     return () => document.removeEventListener('visibilitychange', handleVisibility);

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import * as authModule from '../../js/auth.js';
 import { init as initDatabase, clearAllData } from '../../js/db.js';
+import { flushPendingSync } from '../lib/syncDebounce.js';
 
 const AuthContext = createContext(null);
 
@@ -37,6 +38,7 @@ export function AuthProvider({ children }) {
   }, []);
 
   const logout = useCallback(async () => {
+    await flushPendingSync();
     await authModule.logout();
     await clearAllData();
     await initDatabase();

--- a/src/lib/syncDebounce.js
+++ b/src/lib/syncDebounce.js
@@ -21,9 +21,35 @@ export function onSyncFailure(fn) {
   return () => _syncFailureListeners.delete(fn);
 }
 
+/** Trigger sync failure listeners directly (for use by loadAll callers). */
+export function notifySyncFailure(syncKey, error) {
+  _notifySyncFailure(syncKey, error);
+}
+
 function _notifySyncFailure(syncKey, error) {
   for (const fn of _syncFailureListeners) {
     try { fn({ syncKey, error }); } catch { /* listener errors must not propagate */ }
+  }
+}
+
+/**
+ * Immediately process all pending sync keys (cancel debounce timer).
+ * Awaits all saves before returning. Used before logout to ensure data reaches the server.
+ */
+export async function flushPendingSync() {
+  if (_syncTimer) {
+    clearTimeout(_syncTimer);
+    _syncTimer = null;
+  }
+  const keys = [..._pendingSyncKeys];
+  _pendingSyncKeys.clear();
+  for (const key of keys) {
+    try {
+      await sync.save(key);
+    } catch (err) {
+      console.warn(`[sync] Failed to save "${key}":`, err.message || err);
+      _notifySyncFailure(key, err);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- **Flush pending syncs before logout** — `clearAllData()` was wiping the database before the 500ms sync debounce fired, losing unsaved data. Now `flushPendingSync()` runs first to ensure all pending course data reaches the server.
- **Surface sync/load failures** — `loadAll()` now throws on server errors instead of silently returning. Failures trigger the SyncStatusBanner so users see a warning when data can't be saved or restored.
- **Previous commit** (already on main): `sync.save()` now throws on unexpected HTTP status codes, errors are logged, and a yellow warning banner appears on sync failures.

## Test plan
- [ ] Log in → start course → interact → sign out → sign in → course data should persist
- [ ] If sync fails, yellow warning banner should appear at top of screen
- [ ] Verify Lambda CORS config includes `PUT` in AllowMethods (if banner appears on every save)

https://claude.ai/code/session_012LVM1S8HZj6k3Gizi5Gc45